### PR TITLE
feat(client): route /api requests via vercel proxy to backend

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "http://13.201.6.203:3001/api/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
Frontend was getting a Mixed Content error because it was calling the EC2 backend over HTTP from an HTTPS Vercel app. API requests are now routed through Vercel rewrites to keep browser traffic over HTTPS.